### PR TITLE
Fix setup.py and call trailerfilter indirectly

### DIFF
--- a/marge/git.py
+++ b/marge/git.py
@@ -13,7 +13,7 @@ TIMEOUT_IN_SECS = 60
 
 
 def _filter_branch_script(trailer_name, trailer_values):
-    filter_script = 'TRAILERS={trailers} {script}'.format(
+    filter_script = 'TRAILERS={trailers} python3 {script}'.format(
         trailers=shlex.quote(
             '\n'.join(
                 '{}: {}'.format(trailer_name, trailer_value)

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,6 @@ setup(
     name='marge',
     version='0.1',
     license='BSD3',
-    py_modules=['marge']
+    packages=['marge'],
+    scripts=['marge.app'],
 )


### PR DESCRIPTION
These two things are enough to make `nix-env --install` work properly
but should be better in general.